### PR TITLE
[feat] Support Disable Appearance Transition

### DIFF
--- a/PanModal/Delegate/PanModalPresentationDelegate.swift
+++ b/PanModal/Delegate/PanModalPresentationDelegate.swift
@@ -19,6 +19,8 @@ import UIKit
  ```
  */
 public class PanModalPresentationDelegate: NSObject {
+    
+    public var disableAppearanceTransition: Bool = false
 
     /**
      Returns an instance of the delegate, retained for the duration of presentation
@@ -35,14 +37,20 @@ extension PanModalPresentationDelegate: UIViewControllerTransitioningDelegate {
      Returns a modal presentation animator configured for the presenting state
      */
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return PanModalPresentationAnimator(transitionStyle: .presentation)
+        return PanModalPresentationAnimator(
+            transitionStyle: .presentation,
+            disableAppearanceTransition: disableAppearanceTransition
+        )
     }
 
     /**
      Returns a modal presentation animator configured for the dismissing state
      */
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return PanModalPresentationAnimator(transitionStyle: .dismissal)
+        return PanModalPresentationAnimator(
+            transitionStyle: .dismissal,
+            disableAppearanceTransition: disableAppearanceTransition
+        )
     }
 
     /**

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -96,6 +96,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var showDragIndicator: Bool {
         return shouldRoundTopCorners
     }
+    
+    var disableAppearanceTransition: Bool {
+        return false
+    }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -172,6 +172,14 @@ public protocol PanModalPresentable: AnyObject {
      Default value is true.
      */
     var showDragIndicator: Bool { get }
+    
+    /**
+     A flag to determine to perform  apperence transaction when
+     presenting or dismissing the view controller.
+
+     Default value is true.
+     */
+    var disableAppearanceTransition: Bool { get }
 
     /**
      Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -47,16 +47,18 @@ extension UIViewController: PanModalPresenter {
         /**
          Here, we deliberately do not check for size classes. More info in `PanModalPresentationDelegate`
          */
-
+        let presentationDelegate = PanModalPresentationDelegate.default
+        presentationDelegate.disableAppearanceTransition = viewControllerToPresent.disableAppearanceTransition
+        
         if UIDevice.current.userInterfaceIdiom == .pad {
             viewControllerToPresent.modalPresentationStyle = .popover
             viewControllerToPresent.popoverPresentationController?.sourceRect = sourceRect
             viewControllerToPresent.popoverPresentationController?.sourceView = sourceView ?? view
-            viewControllerToPresent.popoverPresentationController?.delegate = PanModalPresentationDelegate.default
+            viewControllerToPresent.popoverPresentationController?.delegate = presentationDelegate
         } else {
             viewControllerToPresent.modalPresentationStyle = .custom
             viewControllerToPresent.modalPresentationCapturesStatusBarAppearance = true
-            viewControllerToPresent.transitioningDelegate = PanModalPresentationDelegate.default
+            viewControllerToPresent.transitioningDelegate = presentationDelegate
         }
 
         present(viewControllerToPresent, animated: true, completion: completion)


### PR DESCRIPTION
###  Summary

PanModalPresentationAnimator 支持 disableAppearanceTransition 属性，用于可以禁止在 present 或 dismis 时，触发 source view controller 的生命周期方法：viewDidAppear、viewDidDisappear，这将与 modalPresentationStyle = .overFullScreen 的系统的 modal 行为保持一致。